### PR TITLE
 added(ui): ability to search feature flags by name

### DIFF
--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -10,9 +10,15 @@ module Flipper
 
         def get
           @page_title = 'Features'
+          @search = params['search']
+
           @features = flipper.features.map do |feature|
             Decorators::Feature.new(feature)
           end.sort
+
+          if @search
+            @features = @features.select { |feature| feature.name.match(@search) }
+          end
 
           @show_blank_slate = @features.empty?
 

--- a/lib/flipper/ui/views/add_feature.erb
+++ b/lib/flipper/ui/views/add_feature.erb
@@ -12,10 +12,33 @@
       <input type="text" name="value" size="30" placeholder="ie: search, new_pricing, etc." autofocus class="form-control mr-2 mb-2 mb-md-0">
       <input type="submit" value="Add Feature" class="btn btn-light">
     </form>
-    <p class="text-muted">
-      Recommended naming conventions: lower case, <a href="https://en.wikipedia.org/wiki/Snake_case">snake case</a>, underscores over dashes.
-      <strong>Good</strong>: foo_bar, foo.
-      <strong>Bad</strong>: FooBar, Foo Bar, foo bar, foo-bar.
+
+    <p class="text-muted mt-5">
+      Recommended naming conventions: <em>temp?_platform_area_feature</em>
     </p>
+    <ul class="text-muted">
+      <li>
+        <strong>temp?</strong>:
+        Feature flags that are prefixed with temp_ are considered temporary.
+        These flags have an expiration date in which it will be removed.
+        Flags that do not have a prefix of temp_ are considered permanent
+        and have no expiration date.
+      </li>
+      <li>
+        <strong>platform</strong>:
+        Indicates the platform in which this feature flag is used, e.g. web, ios, android, etc.
+      </li>
+      <li>
+        <strong>area</strong>:
+        Indicates the area of business that this flag affects, e.g. checkout, onfeet, editorial, etc.
+      </li>
+      <li>
+        <strong>feature</strong>:
+        A short identifier to convey what the flag is intended to control, e.g. afterpay, sales_tax, nav_2, etc.
+      </li>
+    </ul>
+    <em class="text-muted">
+      Ex: web_checkout_afterpay (permanent) temp_web_header_nav2 (temporary)
+    </em>
   </div>
 </div>

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -1,25 +1,38 @@
-<% if @show_blank_slate %>
-  <div class="jumbotron text-center">
-    <span class="mega-octicon octicon-plus"></span>
-    <span class="mega-octicon octicon-list-unordered"></span>
-    <span class="mega-octicon octicon-zap"></span>
-    <% if Flipper::UI.configuration.fun %>
-      <h4>But I've got a blank space baby...</h4>
-      <p>And I'll flip your features.</p>
-      <div class="embed-responsive embed-responsive-16by9">
-        <iframe class="embed-responsive-item" width="560" height="315" src="https://www.youtube.com/embed/e-ORhEE9VVg" frameborder="0" allowfullscreen></iframe>
+<div class="card">
+  <div class="card-header">
+    <div class="container">
+      <div class="row">
+        <h4 class="col">Features</h4>
+        <form class="col" action="<%= script_name %>/features" method="get">
+          <div class="input-group">
+            <input name="search" type="text" class="form-control" placeholder="<%= @search %>">
+            <button type="submit" class="btn btn-primary">Search</button>
+          </div>
+        </form>
       </div>
-    <% else %>
-      <h4>There aren't any features to configure.</h4>
-      <p>
-        Check the <a href="https://github.com/jnunemaker/flipper#examples">examples</a> to
-        learn how to add one.
-      </p>
-    <% end %>
+    </div>
   </div>
-<% else %>
-  <div class="card">
-    <h4 class="card-header">Features</h4>
+
+  <% if @show_blank_slate %>
+    <div class="jumbotron text-center">
+      <span class="mega-octicon octicon-plus"></span>
+      <span class="mega-octicon octicon-list-unordered"></span>
+      <span class="mega-octicon octicon-zap"></span>
+      <% if Flipper::UI.configuration.fun %>
+        <h4>But I've got a blank space baby...</h4>
+        <p>And I'll flip your features.</p>
+        <div class="embed-responsive embed-responsive-16by9">
+          <iframe class="embed-responsive-item" width="560" height="315" src="https://www.youtube.com/embed/e-ORhEE9VVg" frameborder="0" allowfullscreen></iframe>
+        </div>
+      <% else %>
+        <h4>There aren't any features to configure.</h4>
+        <p>
+          Check the <a href="https://github.com/jnunemaker/flipper#examples">examples</a> to
+          learn how to add one.
+        </p>
+      <% end %>
+    </div>
+  <% else %>
     <table class="table">
       <thead>
         <tr class="d-flex">
@@ -47,5 +60,5 @@
         <% end %>
       </tbody>
     </table>
-  </div>
-<% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
### Purpose
As the FE team relies more heavily on Flipper for development, we'll need to keep staging and production feature flags in sync. One thing that would help us is to have a dedicated view for just the feature flags that we care about.

### Changes
- add the ability to search feature flags by name (https://github.com/goatapp/flipper/commit/fc3b25fc81b48c1785593a8edee690825d784209)
<img width="1127" alt="Screen Shot 2019-06-28 at 8 44 28 AM" src="https://user-images.githubusercontent.com/3462236/60355885-5b6b4400-9984-11e9-9166-8a07e04166a6.png">

- update naming convention on new feature view (https://github.com/goatapp/flipper/commit/22cc903d1484f666ef38a481dacd5c061afd892b)
<img width="1127" alt="Screen Shot 2019-06-28 at 9 00 06 AM" src="https://user-images.githubusercontent.com/3462236/60355890-61612500-9984-11e9-8a3e-17924c243fa1.png">


### Testing Done
- forked https://github.com/jnunemaker/flipper
- added `gem 'flipper-ui', path: '<local path to>/flipper'`
- `bundle` && visually tested changes

### Considerations
Since this was forked from v0.16.2, it'll require that we upgrade `flipper` to v0.16.2 before we can use the updated `flipper-ui`. It might be worth it to first bump `flipper` on our current apps to v0.16.2. Although, I checked the [CHANGELOG](https://github.com/jnunemaker/flipper/blob/master/Changelog.md) and there doesn't seem to be any major risky changes since v0.14.0 (currently, what we're on).
